### PR TITLE
Add Jest tests for game modal

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,6 +31,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests
+        run: npm test
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/js/games.js
+++ b/js/games.js
@@ -129,3 +129,6 @@ function initPlayButtonEffects() {
 
 // Initialize play button effects
 window.addEventListener('load', initPlayButtonEffects);
+if (typeof module !== 'undefined') {
+    module.exports = { openGame, closeGame };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "totallymaths",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.2",
+    "jsdom": "^22.1.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/tests/gameModal.test.js
+++ b/tests/gameModal.test.js
@@ -1,0 +1,40 @@
+const { openGame, closeGame } = require('../js/games');
+
+function setupDOM() {
+  document.body.innerHTML = `
+    <div id="gameModal" style="display:none"></div>
+    <h1 id="modalTitle"></h1>
+    <iframe id="gameFrame"></iframe>
+  `;
+}
+
+describe('game modal functions', () => {
+  beforeEach(() => {
+    setupDOM();
+    document.body.style.overflow = 'auto';
+  });
+
+  test('openGame sets modal info and shows modal', () => {
+    openGame('Cool Game', 'https://example.com');
+    const modal = document.getElementById('gameModal');
+    const modalTitle = document.getElementById('modalTitle');
+    const gameFrame = document.getElementById('gameFrame');
+
+    expect(modal.style.display).toBe('block');
+    expect(modalTitle.textContent).toBe('Cool Game');
+    expect(gameFrame.src).toBe('https://example.com/');
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  test('closeGame hides modal and clears frame', () => {
+    // First open to set values
+    openGame('Test', 'https://example.com');
+    closeGame();
+    const modal = document.getElementById('gameModal');
+    const gameFrame = document.getElementById('gameFrame');
+
+    expect(modal.style.display).toBe('none');
+    expect(gameFrame.src).toBe('');
+    expect(document.body.style.overflow).toBe('auto');
+  });
+});


### PR DESCRIPTION
## Summary
- add package.json with Jest and jsdom
- export modal functions from `js/games.js`
- add unit tests for `openGame` and `closeGame`
- run npm install and npm test in workflow

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68754a77cd488326898c51f5da07c39a