### PR TITLE
Fix policy violation: remove proxy iframe

### DIFF
--- a/games/roblox.html
+++ b/games/roblox.html
@@ -51,18 +51,10 @@
         <!-- Game Container -->
         <div class="game-container">
             <div class="game-wrapper">
-                <iframe id="gameFrame" 
-                        src="https://gointospace.app/&" 
-                        frameborder="0" 
-                        allow="fullscreen; autoplay; microphone; camera"
-                        allowfullscreen
-                        class="game-iframe">
-                </iframe>
-                
-                <!-- Fullscreen Button -->
-                <button id="fullscreenBtn" class="fullscreen-btn" onclick="toggleFullscreen()">
-                    ⛶ Play Fullscreen
-                </button>
+                <p style="padding: 2rem; text-align: center;">
+                    The Roblox web client cannot be embedded here. To play, please visit
+                    <a href="https://www.roblox.com" target="_blank" rel="noopener">Roblox's official website</a>.
+                </p>
             </div>
             
             <!-- Game Controls Info -->


### PR DESCRIPTION
## Summary
- remove `gointospace.app` proxy embed from Roblox page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687681d8aea883269364bbae6081d48a